### PR TITLE
Fix typo, broken links, formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ LabVIEW & C, makes it a perfect tool in education or rapid product development.
 # Where to get one?
 Red Pitaya boards can be purchased @ [RedPitaya online store](https://www.redpitaya.com/Catalog).
 To better understand how product specifications differ from each other we suggest you look at
-the [hardware specifications comparison table](https://redpitaya.readthedocs.io/en/latest/developerGuide/125-10/vs.html) 
+the [hardware specifications comparison table](https://redpitaya.readthedocs.io/en/latest/developerGuide/hardware/compares/vs.html) 
 & Supported features and apps by [Red Pitaya model table](https://redpitaya.readthedocs.io/en/latest/appsFeatures/supportedFeaturesAndApps.html).
 
 
@@ -24,9 +24,9 @@ Once you connect to Red Pitaya from WEB browser it can be immediately used as:
 - Bode analyzer
 - LCR meter
 - Vector Network Analyzer
-- and more..
+- and more...
 There are also many other (contributed) applications available on RedPitaya marketplace.
-For more information about RedPitaya apps click [here](https://redpitaya.readthedocs.io/en/latest/appsFeatures/apps-featured/apps-featured.html).
+For more information about RedPitaya apps click [here](https://redpitaya.readthedocs.io/en/latest/appsFeatures/appsFeatures.html).
 
 
 # How to start using Red Pitaya as SDR (software defined radio)?
@@ -38,20 +38,25 @@ latest software for is [Pavel’s repository](http://pavel-demin.github.io/red-p
 There are several ways to program / develop with Red Pitaya.
 
 1. Remote control / programming
+
    Remote control can be done by using most popular rapid prototyping development tools
    MATLAB, LABview, SCILAB or Python remotely. There are [several examples](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/remoteControl.html) available.
 
 2. Programing Red Pitaya directly from WEB browser / Python
-   Red Pitaya can be programmed in Python directly from the WEB browser using [Jupyter](https://redpitaya.readthedocs.io/en/latest/appsFeatures/jupyter/Jupyter.html?highlight=jupyter).
+
+Red Pitaya can be programmed in Python directly from the WEB browser using [Jupyter](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/jupyter/Jupyter.html?highlight=jupyter).
 
 3. C/C++ programming
-   RedPitaya hardware features can be easily accessed through C APIs. Many starting examples are available at this [link](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/remoteControl.html#examples).
+
+RedPitaya hardware features can be easily accessed through C APIs. Many starting examples are available at this [link](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/remoteControl.html#examples).
 
 4. FPGA programming
-   Information on how to copile Red Pitaya open source FPGA code is [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/fpga.html).
 
-5. Creating own WEB applications
-   Instructions on how to create your own Red Pitaya WEB applications can be found [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/software/webApps.html).
+Information on how to compile Red Pitaya open source FPGA code is [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/software/build/fpga/fpga.html).
+
+5. Creating your own WEB applications
+
+Instructions on how to create your own Red Pitaya WEB applications can be found [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/software/build/webapp/webApps.html).
 
 
 # How to interface Red Pitaya with other hardware or sensors?
@@ -60,13 +65,15 @@ Beside fast analog inputs and outputs Red Pitaya comes with an extension connect
 There are two main extension possibilities:
 
 1. Using already available sensor extension module by RedPitaya
-   Sensors extension module provides direct connection to GroveSensors (e.g. Temperature sensor, Motion sensor,Touch sensor, Button, Switch, Tilt, Potentiometer, Light sensor, Air quality sensor, Vibration sensor, Moisture sensor, Water sensor, Alcohol sensor, Barometer not supported at the moment, Sound sensor, UV sensor, Accelerometer, Relay). Sensor extension module also provide compatibility with arduino extension modules. More examples and information can be found at this [link](https://redpitaya.readthedocs.io/en/latest/appsFeatures/jupyter/Jupyter.html?highlight=jupyter).
 
-2. Creating own add on module that connects to extension connector
-   For more information about extension connector click [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/125-14/extent.html)
+Sensors extension module provides direct connection to GroveSensors (e.g. Temperature sensor, Motion sensor,Touch sensor, Button, Switch, Tilt, Potentiometer, Light sensor, Air quality sensor, Vibration sensor, Moisture sensor, Water sensor, Alcohol sensor, Barometer not supported at the moment, Sound sensor, UV sensor, Accelerometer, Relay). Sensor extension module also provide compatibility with Arduino extension modules. More examples and information can be found at this [link](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/jupyter/Jupyter.html?highlight=jupyter).
+
+2. Creating your own addon module that connects to the extension connector
+
+For more information about extension connector click [here](https://redpitaya.readthedocs.io/en/latest/developerGuide/hardware/ext_modules.html)
 
 # How to start teaching with RedPitaya?
-[Teaching lectures / material](https://redpitaya.readthedocs.io/en/latest/teaching/teaching.html).
+[Teaching lectures / material](https://redpitaya.com/teaching-materials/).
 
 
 


### PR DESCRIPTION
Fix a typo.

Fix the formatting so the numbered headers do not run on into the paragraph.

Fix broken links. I had some trouble with the teaching link (last one on the page). I could not find any teaching references on redpitaya.readthedocs.io, so I chose to link to the Red Pitaya corporate site.